### PR TITLE
Allow custom profiles. Remove un-needed intermediary 'contrib' level

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
   "repositories": [
     { "type": "composer", "url": "https://packages.drupal.org/8" },
     { "type": "path", "url": "./custom/modules/*"},
-    { "type": "path", "url": "./custom/themes/*"}
+    { "type": "path", "url": "./custom/themes/*"},
+    { "type": "path", "url": "./custom/profiles/*"}
   ],
   "scripts": {
     "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -47,9 +48,9 @@
     "installer-paths": {
       "build/core": ["type:drupal-core"],
       "build/libraries/{$name}": ["type:drupal-library"],
-      "build/modules/contrib/{$name}": ["type:drupal-module"],
-      "build/profiles/contrib/{$name}": ["type:drupal-profile"],
-      "build/themes/contrib/{$name}": ["type:drupal-theme"]
+      "build/modules/{$name}": ["type:drupal-module"],
+      "build/profiles/{$name}": ["type:drupal-profile"],
+      "build/themes/{$name}": ["type:drupal-theme"]
     }
   }
 }


### PR DESCRIPTION
While we allow in `robo.yml` to specify a different profile, than `oe_profile`, we should allow also custom profiles to be symlinked.

Also, while all extensions are installed in the same place (under `contrib/`), **regardless if they are contrib or custom**, it just doesn't make sense to keep that intermediary level:

- `build/modules/contrib/some_module` -> `build/modules/some_module`
- `build/profiles/contrib/oe_profile` -> `build/profiles/oe_profile`